### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/tyki6/MyJWT/security/code-scanning/9](https://github.com/tyki6/MyJWT/security/code-scanning/9)

Add an explicit top-level `permissions` block in `.github/workflows/lint.yml` so all jobs inherit least-privilege token access.

Best fix without changing functionality:
- Insert at workflow root (after `workflow_dispatch:` and before `jobs:`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout` and read-only lint/doc workflows. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
